### PR TITLE
Feat: 러닝페이지 바텀시트 구현

### DIFF
--- a/src/assets/svg/dropdown.svg
+++ b/src/assets/svg/dropdown.svg
@@ -1,0 +1,3 @@
+<svg width="10" height="6" viewBox="0 0 10 6" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 1L4.29289 4.29289C4.68342 4.68342 5.31658 4.68342 5.70711 4.29289L9 1" stroke="#1A1A1A" stroke-linecap="round"/>
+</svg>

--- a/src/assets/svg/input-delete.svg
+++ b/src/assets/svg/input-delete.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="8" cy="8" r="8" fill="#D9D9D9"/>
+<path d="M5 5L11 11" stroke="white" stroke-linecap="round"/>
+<path d="M11 5L5 11" stroke="white" stroke-linecap="round"/>
+</svg>

--- a/src/pages/mate/MatePage.tsx
+++ b/src/pages/mate/MatePage.tsx
@@ -1,10 +1,7 @@
-import MainComponent from './components/Dropdown/MainDropdown';
-
 export default function MatePage() {
   return (
     <div className="p-4">
       메이트
-      <MainComponent />
     </div>
   );
 }

--- a/src/pages/mate/MatePage.tsx
+++ b/src/pages/mate/MatePage.tsx
@@ -1,3 +1,10 @@
+import MainComponent from './components/Dropdown/MainDropdown';
+
 export default function MatePage() {
-  return <main className="p-4">메이트</main>;
+  return (
+    <div className="p-4">
+      메이트
+      <MainComponent />
+    </div>
+  );
 }

--- a/src/pages/mate/components/Dropdown/BottomSheet.tsx
+++ b/src/pages/mate/components/Dropdown/BottomSheet.tsx
@@ -24,7 +24,9 @@ export function BottomSheet({
 
   const handleTouchMove = (e: React.TouchEvent) => {
     const deltaY = e.touches[0].clientY - startY.current;
-    if (deltaY > 0) setDragY(deltaY);
+    if (deltaY > 0) {
+      setDragY(deltaY);
+    }
   };
 
   const handleTouchEnd = () => {
@@ -37,7 +39,7 @@ export function BottomSheet({
   return (
     <div
       className={[
-        'fixed inset-0 z-[100] transition-opacity duration-300',
+        'fixed inset-0 z-[100] transition-opacity duration-300 flex justify-center items-end',
         open ? 'opacity-100' : 'pointer-events-none opacity-0',
       ].join(' ')}
     >
@@ -45,39 +47,40 @@ export function BottomSheet({
         className="absolute inset-0 bg-black/20"
         onClick={onClose}
       />
-      <div
-        role="dialog"
-        aria-modal="true"
-        className={[
-          'absolute inset-x-0 bottom-0',
-          'h-[420px] pb-[calc(env(safe-area-inset-bottom)+12px)]',
-          'rounded-t-[20px] bg-white ',
-          'transform transition-transform duration-300',
-          open ? 'translate-y-0' : 'translate-y-full',
-        ].join(' ')}
-        style={{
-          transform: open ? `translateY(${dragY}px)` : 'translateY(100%)',
-          transition: dragY > 0 ? 'none' : undefined,
-        }}
-        onTouchStart={handleTouchStart}
-        onTouchMove={handleTouchMove}
-        onTouchEnd={handleTouchEnd}
-      >
-        <div className="w-10 h-1 bg-gray1/70 rounded-full mx-auto mt-3 mb-3" />
-        {children}
-        <div className="flex px-4 gap-[10px] py-4">
-          <button
-            onClick={onReset}
-            className="w-[100px] rounded-[8px] py-3 text-sm bg-white border border-gray2 text-black"
-          >
-            초기화
-          </button>
-          <button
-            onClick={onApply}
-            className="flex-1 rounded-[8px] py-3 text-sm font-medium bg-main2 text-white"
-          >
-            적용하기
-          </button>
+      <div className="relative w-full min-w-[375px] max-w-[430px]">
+        <div
+          role="dialog"
+          aria-modal="true"
+          onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
+          onTouchEnd={handleTouchEnd}
+          className={[
+            'relative w-full h-[420px] pb-[calc(env(safe-area-inset-bottom)+12px)]',
+            'rounded-t-[20px] bg-white w-full pt-1',
+            'transform transition-transform duration-300',
+            open ? 'translate-y-0' : 'translate-y-full',
+          ].join(' ')}
+          style={{
+            transform: open ? `translateY(${dragY}px)` : 'translateY(100%)',
+            transition: dragY > 0 ? 'none' : undefined,
+          }}
+        >
+          <div className="w-10 h-1 mt-4 bg-gray1/70 rounded-full mx-auto  mb-3 cursor-grab" />
+          {children}
+          <div className="flex px-4 gap-[10px] py-4">
+            <button
+              onClick={onReset}
+              className="w-[100px] rounded-[8px] py-3 text-sm bg-white border border-gray2 text-black"
+            >
+              초기화
+            </button>
+            <button
+              onClick={onApply}
+              className="flex-1 rounded-[8px] py-3 text-sm font-medium bg-main2 text-white"
+            >
+              적용하기
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/pages/mate/components/Dropdown/MainDropdown.tsx
+++ b/src/pages/mate/components/Dropdown/MainDropdown.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Tag } from './Tag';
-import { IcSvgInputDelete } from '../../../../shared/icons';
+import { IcSvgInputDelete } from '@/shared/icons';
 
 export default function MainDropDown() {
   const [isDistanceSelected, setDistanceSelected] = useState(false);
@@ -53,7 +53,7 @@ export default function MainDropDown() {
               />
               {minDistance && (
                 <button
-                  onClick={() => setMinDistance('')} 
+                  onClick={() => setMinDistance('')}
                   className="absolute right-2 top-1/2 -translate-y-1/2"
                 >
                   <IcSvgInputDelete
@@ -75,7 +75,7 @@ export default function MainDropDown() {
               />
               {maxDistance && (
                 <button
-                  onClick={() => setMaxDistance('')} 
+                  onClick={() => setMaxDistance('')}
                   className="absolute right-2 top-1/2 -translate-y-1/2"
                 >
                   <IcSvgInputDelete

--- a/src/pages/mate/components/Dropdown/MainDropdown.tsx
+++ b/src/pages/mate/components/Dropdown/MainDropdown.tsx
@@ -1,10 +1,33 @@
 import { useState } from 'react';
 import { Tag } from './Tag';
+import { IcSvgInputDelete } from '../../../../shared/icons';
 
-export default function MainComponent() {
+export default function MainDropDown() {
   const [isDistanceSelected, setDistanceSelected] = useState(false);
   const [isPaceSelected, setPaceSelected] = useState(false);
   const [isTimeSelected, setTimeSelected] = useState(false);
+
+  const [minDistance, setMinDistance] = useState('');
+  const [maxDistance, setMaxDistance] = useState('');
+
+  const handleMinDistanceChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    if (value === '' || /^[0-9\b]+$/.test(value)) {
+      setMinDistance(value);
+    }
+  };
+
+  const handleMaxDistanceChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    if (value === '' || /^[0-9\b]+$/.test(value)) {
+      setMaxDistance(value);
+    }
+  };
+
+  const clearDistance = () => {
+    setMinDistance('');
+    setMaxDistance('');
+  };
 
   return (
     <div className="flex flex-row flex-wrap justify-left p-4 gap-3">
@@ -12,23 +35,57 @@ export default function MainComponent() {
         label="거리"
         selected={isDistanceSelected}
         onApply={() => setDistanceSelected(true)}
-        onReset={() => setDistanceSelected(false)}
+        onReset={() => {
+          setDistanceSelected(false);
+          clearDistance();
+        }}
       >
         <div className="px-4 pt-3 pb-">
           <p className="text-[18px] font-bold pl-3 text-black">거리</p>
-          <div className="my-4 flex items-center justify-center space-x-2">
-            <input
-              type="text"
-              placeholder="0"
-              className="w-[112px] h-9 px-3 rounded-md border border-gray-300 text-[14px] text-left "
-            />
+          <div className="my-4 flex items-center justify-center space-x-2 relative">
+            <div className="relative">
+              <input
+                type="text"
+                placeholder="0"
+                className="w-[112px] h-9 px-3 rounded-md border border-gray-300 text-[14px] text-left pr-8"
+                value={minDistance}
+                onChange={handleMinDistanceChange}
+              />
+              {minDistance && (
+                <button
+                  onClick={() => setMinDistance('')} // 첫 번째 입력값만 초기화
+                  className="absolute right-2 top-1/2 -translate-y-1/2"
+                >
+                  <IcSvgInputDelete
+                    width={16}
+                    height={16}
+                  />
+                </button>
+              )}
+            </div>
             <span className="text-[14px] ">Km</span>
             <span className="text-[14px] mx-2">~</span>
-            <input
-              type="text"
-              placeholder="0"
-              className="w-[112px] h-9 px-3 rounded-md border border-gray-300 text-[14px] text-left "
-            />
+            {/* 두 번째 입력란 (최대 거리) */}
+            <div className="relative">
+              <input
+                type="text"
+                placeholder="0"
+                className="w-[112px] h-9 px-3 rounded-md border border-gray-300 text-[14px] text-left pr-8"
+                value={maxDistance}
+                onChange={handleMaxDistanceChange}
+              />
+              {maxDistance && (
+                <button
+                  onClick={() => setMaxDistance('')} // 두 번째 입력값만 초기화
+                  className="absolute right-2 top-1/2 -translate-y-1/2"
+                >
+                  <IcSvgInputDelete
+                    width={16}
+                    height={16}
+                  />
+                </button>
+              )}
+            </div>
             <span className="text-[14px]">Km</span>
           </div>
         </div>
@@ -71,7 +128,6 @@ export default function MainComponent() {
           </div>
         </div>
       </Tag>
-
       <Tag
         label="시작"
         selected={isTimeSelected}
@@ -104,6 +160,7 @@ export default function MainComponent() {
               placeholder="00"
               className="w-[42px] h-9 px-3 rounded-md border border-gray-300 text-[14px] text-left "
             />
+            <span className="text-[24px]">"</span>
           </div>
         </div>
       </Tag>

--- a/src/pages/mate/components/Dropdown/MainDropdown.tsx
+++ b/src/pages/mate/components/Dropdown/MainDropdown.tsx
@@ -53,7 +53,7 @@ export default function MainDropDown() {
               />
               {minDistance && (
                 <button
-                  onClick={() => setMinDistance('')} // 첫 번째 입력값만 초기화
+                  onClick={() => setMinDistance('')} 
                   className="absolute right-2 top-1/2 -translate-y-1/2"
                 >
                   <IcSvgInputDelete
@@ -65,7 +65,6 @@ export default function MainDropDown() {
             </div>
             <span className="text-[14px] ">Km</span>
             <span className="text-[14px] mx-2">~</span>
-            {/* 두 번째 입력란 (최대 거리) */}
             <div className="relative">
               <input
                 type="text"
@@ -76,7 +75,7 @@ export default function MainDropDown() {
               />
               {maxDistance && (
                 <button
-                  onClick={() => setMaxDistance('')} // 두 번째 입력값만 초기화
+                  onClick={() => setMaxDistance('')} 
                   className="absolute right-2 top-1/2 -translate-y-1/2"
                 >
                   <IcSvgInputDelete

--- a/src/pages/mate/components/Dropdown/Tag.tsx
+++ b/src/pages/mate/components/Dropdown/Tag.tsx
@@ -1,6 +1,6 @@
 import { useState, type ReactNode } from 'react';
-import { IcSvgDropdown } from '../../../../shared/icons';
 import { BottomSheet } from './BottomSheet';
+import { IcSvgDropdown } from '../../../../shared/icons';
 
 type TagProps = {
   label: string;

--- a/src/pages/mate/components/Dropdown/Tag.tsx
+++ b/src/pages/mate/components/Dropdown/Tag.tsx
@@ -1,6 +1,6 @@
 import { useState, type ReactNode } from 'react';
 import { BottomSheet } from './BottomSheet';
-import { IcSvgDropdown } from '../../../../shared/icons';
+import { IcSvgDropdown } from '@/shared/icons';
 
 type TagProps = {
   label: string;

--- a/src/pages/mate/components/FloatingButton.tsx
+++ b/src/pages/mate/components/FloatingButton.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { IcSvgPencil, IcSvgTalk } from '../icons';
+import { IcSvgPencil, IcSvgTalk } from '@/shared/icons';
 
 type FloatingButtonProps = {
   children: ReactNode;

--- a/src/pages/running/components/BottomSheet.tsx
+++ b/src/pages/running/components/BottomSheet.tsx
@@ -1,0 +1,81 @@
+import { useRef, useState } from 'react';
+
+type RunningBottomSheetProps = {
+  open: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+};
+
+export function RunningBottomSheet({
+  open,
+  children,
+}: RunningBottomSheetProps) {
+  const [currentHeight, setCurrentHeight] = useState(200);
+  const [isDragging, setIsDragging] = useState(false);
+  const startY = useRef(0);
+  const startHeight = useRef(250);
+  const minHeight = 250;
+  const maxHeight = 480;
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    setIsDragging(true);
+    startY.current = e.touches[0].clientY;
+    startHeight.current = currentHeight;
+  };
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    if (!isDragging) return;
+    e.preventDefault();
+
+    const deltaY = startY.current - e.touches[0].clientY;
+    const newHeight = startHeight.current + deltaY;
+
+    if (newHeight <= maxHeight && newHeight >= minHeight) {
+      setCurrentHeight(newHeight);
+    }
+  };
+
+  const handleTouchEnd = () => {
+    if (!isDragging) return;
+
+    setIsDragging(false);
+
+    if (currentHeight > (minHeight + maxHeight) / 2) {
+      setCurrentHeight(maxHeight);
+    } else {
+      setCurrentHeight(minHeight);
+    }
+  };
+
+  return (
+    <div
+      className={[
+        'fixed inset-0 z-[0] transition-opacity duration-300 flex justify-center items-end',
+        open ? 'opacity-100' : 'pointer-events-none opacity-0',
+      ].join(' ')}
+    >
+      <div className="relative w-full min-w-[375px] max-w-[430px] border-t border-gray2 rounded-t-[20px]">
+        <div
+          role="dialog"
+          aria-modal="true"
+          className={[
+            'relative w-full pb-[calc(env(safe-area-inset-bottom)+12px)]',
+            'rounded-t-[20px] bg-white pt-1',
+            'transform transition-transform duration-300',
+            open ? 'translate-y-0' : 'translate-y-full',
+          ].join(' ')}
+          style={{
+            height: `${currentHeight}px`,
+            transition: isDragging ? 'none' : 'height 0.3s ease-in-out',
+          }}
+          onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
+          onTouchEnd={handleTouchEnd}
+        >
+          <div className="w-10 h-1 mt-3 bg-gray1/30 rounded-full mx-auto mb-3 cursor-grab" />
+          <div className="h-full overflow-y-auto">{children}</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/running/page.tsx
+++ b/src/pages/running/page.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import { RunningBottomSheet } from './components/BottomSheet';
+export default function RunningPage() {
+  const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(true);
+  const [activeTab, setActiveTab] = useState('favorites');
+
+  const handleClose = () => {
+    setIsBottomSheetOpen(false);
+  };
+
+  return (
+    <div className="p-4">
+      러닝 페이지
+      <RunningBottomSheet
+        open={isBottomSheetOpen}
+        onClose={handleClose}
+      >
+        <div className="p-4">
+          <div className="flex justify-center items-center gap-4">
+            <button
+              onClick={() => setActiveTab('favorites')}
+              className={`rounded-[20px] py-2 px-12 font-bold transition-colors duration-200 
+                ${activeTab === 'favorites' ? 'border-2 border-main2 text-main2' : 'border-2 border-gray3 text-gray1'}`}
+            >
+              즐겨찾기
+            </button>
+            <button
+              onClick={() => setActiveTab('recent')}
+              className={`rounded-[20px] py-2 px-12 font-bold transition-colors duration-200 
+                ${activeTab === 'recent' ? 'border-2 border-main2 text-main2' : 'border-2 border-gray3 text-gray1'}`}
+            >
+              최근 경로
+            </button>
+          </div>
+          <div className="mt-4">
+            {activeTab === 'favorites' && <div>즐겨찾기 리스트</div>}
+            {activeTab === 'recent' && <div>최근 경로리스트</div>}
+          </div>
+        </div>
+      </RunningBottomSheet>
+    </div>
+  );
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -6,6 +6,7 @@ import HomePage from '../pages/home/HomePage';
 import SplashPage from '../pages/splash/SplashPage';
 import LoginPage from '../pages/login/LoginPage';
 import MatePage from '../pages/mate/MatePage';
+import RunningPage from '../pages/running/page';
 
 export const router = createBrowserRouter([
   {
@@ -17,6 +18,7 @@ export const router = createBrowserRouter([
       { path: 'splash', element: <SplashPage /> },
       { path: 'login', element: <LoginPage /> },
       { path: 'mate', element: <MatePage /> },
+      { path: 'running', element: <RunningPage /> },
     ],
   },
 ]);

--- a/src/shared/components/bottom-navigation.tsx
+++ b/src/shared/components/bottom-navigation.tsx
@@ -44,7 +44,7 @@ const BottomNavigation = () => {
                 'pointer-events-auto flex flex-col items-center justify-center w-[4.375rem] h-[4.375rem] rounded-full shadow-lg',
                 isActive
                   ? 'bg-main1 text-white font-bold'
-                  : 'bg-main1 text-white',
+                  : 'bg-main3 text-white',
               ].join(' ')
             }
           >

--- a/src/shared/components/bottom-navigation.tsx
+++ b/src/shared/components/bottom-navigation.tsx
@@ -38,7 +38,7 @@ const BottomNavigation = () => {
         </li>
         <li className="pointer-events-none font-bold absolute left-1/2 -translate-x-1/2 -top-[20px] z-10">
           <NavLink
-            to="/runningPage"
+            to="/running"
             className={({ isActive }) =>
               [
                 'pointer-events-auto flex flex-col items-center justify-center w-[4.375rem] h-[4.375rem] rounded-full shadow-lg',

--- a/src/shared/icons/ic_inputdelete.tsx
+++ b/src/shared/icons/ic_inputdelete.tsx
@@ -1,0 +1,24 @@
+import type { SVGProps } from 'react';
+
+const IcSvgInputDelete = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 16 16"
+    {...props}
+  >
+    <circle
+      cx={8}
+      cy={8}
+      r={8}
+      fill="#D9D9D9"
+    />
+    <path
+      stroke="white"
+      strokeLinecap="round"
+      strokeWidth="1.5"
+      d="m5 5 6 6M11 5l-6 6"
+    />
+  </svg>
+);
+export default IcSvgInputDelete;

--- a/src/shared/icons/index.ts
+++ b/src/shared/icons/index.ts
@@ -2,10 +2,11 @@
 // Run `pnpm svgr` to regenerate.
 
 export { default as IcSvgDropdown } from './ic_dropdown';
-export { default as IcSvgPencil } from './ic_pencil';
-export { default as IcSvgTalk } from './ic_talk';
+export { default as IcSvgInputDelete } from './ic_inputdelete';
 export { default as IcSvgMate } from './ic_mate';
 export { default as IcSvgMateFull } from './ic_matefull';
 export { default as IcSvgMyinfo } from './ic_myinfo';
 export { default as IcSvgMyinfoFull } from './ic_myinfofull';
+export { default as IcSvgPencil } from './ic_pencil';
 export { default as IcSvgShoes } from './ic_shoes';
+export { default as IcSvgTalk } from './ic_talk';

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,7 +16,13 @@ export default {
         gray3: '#EAEAEA',
         gray4: '#EAEAEA',
 
+        red: '#E55B5B',
         safe: '#B3FFC6',
+        green: '#37DE61',
+        yellow1: '#FFDA46',
+        yellow2: '#FFFAB3',
+        orange1: '#FFA42C',
+        orange2: '#FFDFB3',
 
         white: '#FFFFFF',
         black: '#1A1A1A',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,6 +2,9 @@
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
+    screens: {
+      mobile: '375px',
+    },
     extend: {
       colors: {
         main1: '#28097C',
@@ -11,7 +14,7 @@ export default {
         gray1: '#767676',
         gray2: '#D9D9D9',
         gray3: '#EAEAEA',
-        gray4: '#EAEAEA', 
+        gray4: '#EAEAEA',
 
         safe: '#B3FFC6',
 

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -6,6 +6,12 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "baseUrl": "./src",
+    "paths": {
+      "@/*": ["*"],
+      "@/shared/icons": ["shared/icons"],
+      "@/shared/*": ["shared/*"]
+    },
 
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

어떤 변경 사항이 있나요?

## #️⃣ 연관된 이슈

- #27 

---
## 📋 작업 상세 내용
- 러닝페이지에 쓰이는 바텀시트 구현
- 메이트 페이지 바텀시트에 숫자만 작성하게 제한, 입력란안에 삭제아이콘 추가
- 추가된 색상 디자인토큰 추가
- alias 적용해서 @/shared/icons 경로 가능합니다

---

## 📸 스크린샷 (선택)

<!--UI/스타일 변경이 있다면, 전/후 비교 스크린샷 또는 데모 GIF 첨부-->

https://github.com/user-attachments/assets/1c930247-d736-4fd5-9133-5a4b0679e15d



## 📌 앞으로의 작업 (선택)

<!--이 PR 이후로 진행해야 할 작업, 남은 TODO 등을 적어주세요.-->


## 💬 리뷰 요구사항 / 의논사항 / 레퍼런스 (선택)

<!--추가적으로 의논사항, 레퍼런스 링크 , 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요-->
